### PR TITLE
update for various flavors, add udocker example for HPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,25 @@
 [![Build Status](https://jenkins.indigo-datacloud.eu/buildStatus/icon?job=Pipeline-as-code/DEEP-OC-org/DEEP-OC-benchmarks_cnn/master)](https://jenkins.indigo-datacloud.eu/job/Pipeline-as-code/job/DEEP-OC-org/job/DEEP-OC-benchmarks_cnn/job/master)
 
 This is a container that will run the DEEP as a Service API component, [DEEPaaS API](https://github.com/indigo-dc/DEEPaaS), with [tf_cnn_benchmarks](https://github.com/tensorflow/benchmarks/tree/master/scripts/tf_cnn_benchmarks) from the TensorFlow team. The source code for integration of [tf_cnn_benchmarks](https://github.com/tensorflow/benchmarks/tree/master/scripts/tf_cnn_benchmarks) with [DEEPaaS API](https://github.com/indigo-dc/DEEPaaS) is located in [benchmarks_cnn_api](https://github.com/deephdc/benchmarks_cnn_api).
-    
+
+The application has several 'flavors' implemented:
+
+ * 'synthetic': generated in-memory data mimicking ImageNet dataset, avoids storage I/O
+ * 'dataset': ca. 5GB subset of real ImageNet data is used (downloaded automatically but may take time!), therefore involves I/O. Useful in comparison with 'synthetic' flavor.
+ * 'pro': possible to customize various inputs: neural network, batch_size, dataset, etc
+
+'synthetic' and 'dataset' have as an input the number of GPUs only, the rest is defined inside the application: 
+Both flavors run sequentially 100 batches of googlenet, inception3, resnet50, vgg16 and sum 'average_examples_per_sec' to derive the final 'score'.
+The optimizer is set to 'sgd'. The batch size is defined per GPU and scaled with the GPU memory. Initial batch_sizes are set for 4GB GPU memory as: 
+
+ * googlenet: 96
+ * inception3: 24
+ * resnet50: 24
+ * vgg16: 16
+
+It is also possible to run both flavors on CPU but the batch_size is fixed to 16 for all neural networks independent of the memory available.
+
+
 ## Running the container
 
 ### Directly from Docker Hub
@@ -16,7 +34,7 @@ To run the Docker container directly from Docker Hub and start using the API
 simply run the following command:
 
 ```bash
-$ docker run -ti -p 5000:5000 -p 6006:6006 deephdc/deep-oc-benchmarks_cnn
+$ docker run -ti -p 5000:5000 -p 6006:6006 deephdc/deep-oc-benchmarks_cnn:flavor
 ```
 
 This command will pull the Docker container from the Docker Hub

--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
     "title": "TF Benchmarks",
     "summary": "tf_cnn_benchmarks accessed via DEEPaaS API",
     "description": [
-	       "[tf_cnn_benchmarks](https://github.com/tensorflow/benchmarks/tree/master/scripts/tf_cnn_benchmarks)",
+		   "[tf_cnn_benchmarks](https://github.com/tensorflow/benchmarks/tree/master/scripts/tf_cnn_benchmarks)",
 	       "from TensorFlow team accessed via [DEEPaaS API](https://github.com/indigo-dc/DEEPaaS)",
            "",
            "tf_cnn_benchmarks contains implementations of several popular convolutional models ",
@@ -12,6 +12,22 @@
            "(please, note that running in distributed mode across multiple hosts is not supported by these Docker images).",
            "See the [High-Performance models guide](https://www.tensorflow.org/performance/performance_models) for more information.",
            "",
+           "The application has several 'flavors' implemented:",
+           "",
+           " * 'synthetic': generated in-memory data mimicking ImageNet dataset, avoids storage I/O",
+           " * 'dataset': ca. 5GB subset of real ImageNet data is used (downloaded automatically but may take time!), therefore involves I/O. Useful in comparison with 'synthetic' flavor.",
+           " * 'pro': possible to customize various inputs: neural network, batch_size, dataset, etc",
+           "",
+           "'synthetic' and 'dataset' have as an input the number of GPUs only, the rest is defined inside the application: ",
+           "Both flavors run sequentially 100 batches of googlenet, inception3, resnet50, vgg16, and sum 'average_examples_per_sec' to derive the final 'score'." ,
+           "The optimizer is set to 'sgd'. The batch size is defined per GPU and scaled with the GPU memory. Initial batch_sizes are set for 4GB GPU memory as: \n",
+           " * googlenet: 96",
+           " * inception3: 24",
+           " * resnet50: 24",
+           " * vgg16: 16",
+           "",
+           "It is also possible to run both flavors on CPU but the batch_size is fixed to 16 for all neural networks independent of the memory available.",
+           "",
            "**References**\n",
            "[1] TF CNN Benchmarks: <a href=https://github.com/tensorflow/benchmarks/tree/master/scripts/tf_cnn_benchmarks>https://github.com/tensorflow/benchmarks/tree/master/scripts/tf_cnn_benchmarks</a>"
 	],
@@ -20,7 +36,7 @@
 	    "tensorflow",
         "cnn",
         "trainable",
-	    "api-v2"
+	    "api-v1"
     ],
     "license": "MIT",
     "date_creation": "2019-12-19",
@@ -35,8 +51,19 @@
     },
     "tosca": [
         {
-            "title": "Marathon",
+            "title": "Marathon+Webdav",
             "url": "https://raw.githubusercontent.com/indigo-dc/tosca-templates/master/deep-oc/deep-oc-marathon-webdav.yml",
+            "inputs": [
+                "rclone_conf",
+                "rclone_url",
+                "rclone_vendor",
+                "rclone_user",
+                "rclone_pass"
+            ]
+        },
+        {
+            "title": "Marathon+OneData",
+            "url": "https://raw.githubusercontent.com/indigo-dc/tosca-templates/master/deep-oc/deep-oc-marathon-onedata.yml",
             "inputs": [
                 "rclone_conf",
                 "rclone_url",


### PR DESCRIPTION
The application code (benchmarks_cnn_api) was split to have three main flavors:

'synthetic': generated in-memory data mimicking ImageNet dataset, avoids storage I/O
'dataset': ca. 5GB subset of real ImageNet data is used (downloaded automatically but may take time!), therefore involves I/O. Useful in comparison with 'synthetic' flavor.
'pro': possible to customize various inputs: neural network, batch_size, dataset, etc

Jenkinsfile adjusted accordingly.